### PR TITLE
fix(client-side): Install app button on header

### DIFF
--- a/src/pages/_clientUser/Home.vue
+++ b/src/pages/_clientUser/Home.vue
@@ -5,6 +5,18 @@
             <txt type="title">Today</txt>
             <div class="flex">
                 <icon-button
+                    v-if="pwa.displayMode === 'browser tab'"
+                    svg="download"
+                    :on-click="
+                        () =>
+                            $store.dispatch('openModal', {
+                                name: 'install-pwa',
+                            })
+                    "
+                    :icon-size="28"
+                    class="mr-4"
+                />
+                <icon-button
                     svg="info"
                     :icon-size="32"
                     class="mr-4"
@@ -182,6 +194,7 @@ export default {
         };
     },
     computed: mapState([
+        "pwa",
         "clientUserLoaded",
         "loading",
         "dontLeave",


### PR DESCRIPTION
# TIB App PR

## Changes

A brief list of changes

- Added icon button to open the install modal on client side

## Important

This PR will inherit some shared changes from the PR below to solve the button size on the install modal

- https://github.com/Train-In-Blocks-Ltd/App/pull/134

## Test Cases

What should the reviewer do and expect to happen when testing

1. Head to client user home
2. Click on the install app icon on the top right. **Expect a modal to open**

## Demo

A screenshot or recording of the change.

<img width="946" alt="Screenshot 2022-03-30 at 22 15 51" src="https://user-images.githubusercontent.com/63963445/160932640-5b4876e8-82e3-443a-9ffb-5987e5989415.png">

<img width="1255" alt="Screenshot 2022-03-30 at 22 16 00" src="https://user-images.githubusercontent.com/63963445/160932646-f923b01a-fba4-4969-9293-18903a92f527.png">
