### PR TITLE
fix(home): Help in nav bar opens new tab

### DIFF
--- a/src/components/extensive/NavBar/components/NavLink.vue
+++ b/src/components/extensive/NavBar/components/NavLink.vue
@@ -17,6 +17,7 @@
     <a
         v-else
         :href="link"
+        :target="name === 'Help' && '_blank'"
         :title="name"
         @click="onClick()"
         :class="{ 'md:hidden': name === 'Refresh' }"


### PR DESCRIPTION
# TIB App PR

## Changes

A brief list of changes

- Help icon button now opens in new tab

## Test Cases

What should the reviewer do and expect to happen when testing

1. Press the Help icon button. 
