### PR TITLE
fix: Editor not editable on leave

### DIFF
--- a/src/components/extensive/RichEditor/index.vue
+++ b/src/components/extensive/RichEditor/index.vue
@@ -265,6 +265,10 @@ export default {
                             attr: "newImgs",
                             data: [],
                         });
+                        this.$store.commit("SET_DATA", {
+                            attr: "editor",
+                            data: undefined,
+                        });
                     },
                 });
 


### PR DESCRIPTION
# TIB App PR

## Changes

A brief list of changes

- When the editor is destroyed it resets the Vuex state that disables it.

## Test Cases

What should the reviewer do and expect to happen when testing

1. Head into any editor
2. Navigate elsewhere and confirm the navigation
3. Head back to the previous page of the editor. **You should be able to edit**
