### PR TITLE
fix(elements): Darkmode dropdown option color

### DIFF
--- a/src/components/elements/Dropdown.vue
+++ b/src/components/elements/Dropdown.vue
@@ -18,6 +18,7 @@
                 v-for="(item, index) in items"
                 :key="`option-${index}`"
                 :value="item.value"
+                class="bg-white dark:bg-gray-800"
             >
                 <txt>{{ item.label }}</txt>
             </option>


### PR DESCRIPTION
# TIB App PR

## Changes

A brief list of changes

- Added background colour and dark mode version to dropdown options

## Important

I'm on a Mac so the options dropdown looks different to yours. Please can you test and let me know @joebailey26 

## Test Cases

What should the reviewer do and expect to happen when testing

1. Go into any dropdown in Darkmode.
