### PR TITLE
fix(client): Booking component delete opacity

### DIFF
--- a/src/components/generic/Booking.vue
+++ b/src/components/generic/Booking.vue
@@ -1,7 +1,7 @@
 <template>
     <card-wrapper
         :class="{
-            'border-gray-400 dark:border-gray-400': isInThePast(booking),
+            'border-opacity-60 dark:border-gray-400': isInThePast(booking),
         }"
         class="p-2 sm:p-4"
         no-hover


### PR DESCRIPTION
# TIB App PR

## Changes

A brief list of changes

- Made ```Delete``` not to have low opacity on Past bookings

## Test Cases

What should the reviewer do and expect to happen when testing

1. Check ```Delete``` button on past bookings. **Expect to not have low opacity**

## Demo

A screenshot or recording of the change.

<img width="1019" alt="Screenshot 2022-04-07 at 22 03 21" src="https://user-images.githubusercontent.com/63963445/162307401-6e6f170c-a23a-43dd-a74d-b90fd2b06e0b.png">
<img width="1116" alt="Screenshot 2022-04-07 at 22 06 48" src="https://user-images.githubusercontent.com/63963445/162309032-97a3a356-f5fe-4c64-86ac-d00c5dd7b7a2.png">
