### PR TITLE
fix: Overlapping checkbox on archived client

### DIFF
--- a/src/components/generic/ClientLink.vue
+++ b/src/components/generic/ClientLink.vue
@@ -17,7 +17,7 @@
 <template>
     <card-wrapper class="grid p-4 md:p-8 gap-4" :no-hover="archive">
         <!-- Top section -->
-        <div class="flex">
+        <div class="relative sm:flex">
             <div
                 v-if="client.profile_image"
                 :style="{ backgroundImage: `url(${client.profile_image})` }"
@@ -30,7 +30,7 @@
                 :icon-size="80"
                 class="p-4 border-3 border-gray-800 dark:border-white rounded-full mr-4"
             />
-            <div>
+            <div class="mt-4 sm:mt-0">
                 <txt type="large-body" bold>
                     {{ client.name }}
                 </txt>
@@ -50,7 +50,7 @@
             <checkbox
                 v-if="archive"
                 :item-id="client.client_id"
-                class="ml-auto"
+                class="absolute top-0 right-0"
             />
         </div>
 


### PR DESCRIPTION
# TIB App PR

## Changes

A brief list of changes

- Made client details drop own on mobile
- Checkbox is absolute to avoid overlap

## Test Cases

What should the reviewer do and expect to happen when testing

1. Check an archived client on mobile size

## Demo

A screenshot or recording of the change.

<img width="470" alt="Screenshot 2022-04-09 at 21 23 27" src="https://user-images.githubusercontent.com/63963445/162590501-61a906c5-4e0c-46df-b7da-b439fd55a297.png">
<img width="635" alt="Screenshot 2022-04-09 at 21 23 31" src="https://user-images.githubusercontent.com/63963445/162590504-4c1b4594-0595-46e4-962e-f09bd6758362.png">
<img width="758" alt="Screenshot 2022-04-09 at 21 23 34" src="https://user-images.githubusercontent.com/63963445/162590505-e651e452-9508-4511-95f3-eb47e23f7739.png">
