### PR TITLE
fix: Apply darkmode on load

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -225,8 +225,14 @@ export default class App extends Mixins(MainMixins) {
     async created() {
         appModule.setLoading(true);
         appModule.setAuthenticated(await this.$auth.isAuthenticated());
+        const claims = await this.$auth.getUser();
+        function darkmodeTheme () {
+            const theme = localStorage.getItem("darkmode") ?? claims.theme;
+            if (!!theme) return theme;
+            return "system";
+        }
         this.darkmode(
-            (localStorage.getItem("darkmode") as DarkmodeType) ?? "system"
+            (darkmodeTheme() as DarkmodeType)
         );
         await this.setup();
     }


### PR DESCRIPTION
# TIB App PR

## Changes

A brief list of changes

- Darkmode now applies as soon as the app loads and uses values from local storage.

## Test Cases

What should the reviewer do and expect to happen when testing

1. It may not work on the first-ever load of the app since nothing is in the local storage, however, after that, it will load the theme correctly

## Demo


https://user-images.githubusercontent.com/63963445/170842958-24d462bc-a439-4219-8bba-26d55e223056.mov

